### PR TITLE
Explicitly setting --output for PurgeCSS

### DIFF
--- a/purgecss.rb
+++ b/purgecss.rb
@@ -25,7 +25,7 @@ create_builder "purgecss_builder.rb" do
             css_path = ["output", "_bridgetown", "static", "css", css_file].join("/")
             Bridgetown.logger.info "PurgeCSS", "Purging \#{css_file}"
             oldsize = File.stat(css_path).size / 1000
-            system "./node_modules/.bin/purgecss -c purgecss.config.js -css \#{css_path}"
+            system "./node_modules/.bin/purgecss -c purgecss.config.js -css \#{css_path} --output \#{css_path}"
             newsize = File.stat(css_path).size / 1000
             if newsize < oldsize
               Bridgetown.logger.info "PurgeCSS", "Done! File size reduced from \#{oldsize}kB to \#{newsize}kB"


### PR DESCRIPTION
I copied this setup and purge CSS was outputting to terminal instead of overwriting the file.

So this updates the automation for PurgeCSS to explicitly set the CSS file output as that appeared to fix it :)